### PR TITLE
Add forms for forgot password pages

### DIFF
--- a/src/pages/forgot-password/hooks.ts
+++ b/src/pages/forgot-password/hooks.ts
@@ -1,0 +1,21 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import {
+  type ForgotPasswordFormType,
+  forgotPasswordSchema,
+} from '@pages/forgot-password/model/validation-schema';
+
+export const useForgotPasswordForm = () => {
+  const form = useForm<ForgotPasswordFormType>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: {
+      email: '',
+    },
+    mode: 'onChange',
+  });
+
+  return {
+    form,
+  };
+};

--- a/src/pages/forgot-password/index.tsx
+++ b/src/pages/forgot-password/index.tsx
@@ -1,7 +1,15 @@
+import { ForgotPasswordForm } from '@pages/forgot-password/ui/forgot-password-form';
+
 export const ForgotPassword = (): React.JSX.Element => {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl mb-4">Forgot password page</h1>
+    <div className="flex flex-1 items-center justify-center flex-col">
+      <div className="flex flex-col gap-3 max-w-lg p-8 w-full">
+        <h2 className="mb-6 text-center">Forgot your password?</h2>
+        <p className="mb-6 text-muted-foreground text-center">
+          Enter your email and we will send you a link to reset your password
+        </p>
+        <ForgotPasswordForm />
+      </div>
     </div>
   );
 };

--- a/src/pages/forgot-password/model/validation-schema.ts
+++ b/src/pages/forgot-password/model/validation-schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const forgotPasswordSchema = z.object({
+  email: z.email({
+    pattern: z.regexes.html5Email,
+    message: 'Invalid email format',
+  }),
+});
+
+export type ForgotPasswordFormType = z.infer<typeof forgotPasswordSchema>;

--- a/src/pages/forgot-password/ui/forgot-password-form.tsx
+++ b/src/pages/forgot-password/ui/forgot-password-form.tsx
@@ -1,0 +1,28 @@
+import { useForgotPasswordForm } from '@pages/forgot-password/hooks';
+
+import { Button } from '@shared/ui/button';
+import { Form } from '@shared/ui/form';
+import { Input } from '@shared/ui/input';
+
+import { FormFieldWrapper } from '@/shared/ui/form-field-wrapper';
+
+export const ForgotPasswordForm = (): React.JSX.Element => {
+  const { form } = useForgotPasswordForm();
+
+  return (
+    <Form {...form}>
+      <form className="space-y-6">
+        <FormFieldWrapper control={form.control} name="email" label="Email">
+          {(field) => <Input type="email" placeholder="Email" {...field} />}
+        </FormFieldWrapper>
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={!form.formState.isValid}
+        >
+          Reset Password
+        </Button>
+      </form>
+    </Form>
+  );
+};

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -22,6 +22,14 @@ export const Login = (): React.JSX.Element => (
       >
         Sign up
       </Link>
+      <div className="mt-6">
+        <p className="text-sm text-muted-foreground text-center">
+          Forgot your password?{' '}
+          <Link className="text-primary hover:underline" to={ROUTES.FORGOT}>
+            Reset here
+          </Link>
+        </p>
+      </div>
     </div>
     <img
       src={Rectangle}

--- a/src/pages/reset-password/hooks.ts
+++ b/src/pages/reset-password/hooks.ts
@@ -1,0 +1,22 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import {
+  type ResetPasswordFormType,
+  resetPasswordSchema,
+} from '@pages/reset-password/model/validation-schema';
+
+export const useResetPasswordForm = () => {
+  const form = useForm<ResetPasswordFormType>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  });
+
+  return {
+    form,
+  };
+};

--- a/src/pages/reset-password/index.tsx
+++ b/src/pages/reset-password/index.tsx
@@ -1,7 +1,12 @@
+import { ResetPasswordForm } from '@pages/reset-password/ui/reset-password-form';
+
 export const ResetPassword = (): React.JSX.Element => {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl mb-4">Reset password page</h1>
+    <div className="flex flex-1 items-center justify-center flex-col">
+      <div className="flex flex-col gap-3 max-w-lg p-8 w-full">
+        <h2 className="mb-6 text-center">Enter a new password</h2>
+        <ResetPasswordForm />
+      </div>
     </div>
   );
 };

--- a/src/pages/reset-password/model/validation-schema.ts
+++ b/src/pages/reset-password/model/validation-schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+import { passwordSchema } from '@shared/ui/password-field/model/validation-schema';
+
+export const resetPasswordSchema = z
+  .object({
+    confirmPassword: z.string().trim().min(1, 'Confirm password is required'),
+  })
+  .extend(passwordSchema.shape)
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordFormType = z.infer<typeof resetPasswordSchema>;

--- a/src/pages/reset-password/ui/reset-password-form.tsx
+++ b/src/pages/reset-password/ui/reset-password-form.tsx
@@ -1,0 +1,46 @@
+import { useResetPasswordForm } from '@pages/reset-password/hooks';
+
+import { Button } from '@shared/ui/button';
+import { Form } from '@shared/ui/form';
+import { FormFieldWrapper } from '@shared/ui/form-field-wrapper';
+import { PasswordField } from '@shared/ui/password-field';
+import { PasswordInput } from '@shared/ui/password-input';
+
+export const ResetPasswordForm = (): React.JSX.Element => {
+  const { form } = useResetPasswordForm();
+
+  return (
+    <Form {...form}>
+      <form className="space-y-6">
+        <FormFieldWrapper
+          control={form.control}
+          name="password"
+          label="Password"
+        >
+          {(field) => (
+            <PasswordField
+              value={field.value ?? ''}
+              onChange={field.onChange}
+            />
+          )}
+        </FormFieldWrapper>
+
+        <FormFieldWrapper
+          control={form.control}
+          name="confirmPassword"
+          label="Confirm Password"
+        >
+          {(field) => <PasswordInput {...field} />}
+        </FormFieldWrapper>
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={!form.formState.isValid}
+        >
+          Save Password
+        </Button>
+      </form>
+    </Form>
+  );
+};


### PR DESCRIPTION
## 🚀 Type of change

- [x] Feature
- [ ] Fix / Bugfix
- [ ] Refactor (no logic change)
- [ ] Chore / Maintenance
- [ ] Styling / UI
- [ ] Tests
- [ ] Documentation
- [ ] Project settings / configs

## 📋 Summary

- Created forms for forgot and reset password pages

## 🧪 How to test

1. Run `pnpm run dev`
2. Open `http://localhost:6006`
3. Open the login page
4. Click on the link to the forgot page
5. Open `/reset` route

## 📸 Screenshots / video (optional)
<img width="1285" height="837" alt="Снимок экрана 2025-07-23 в 20 53 08" src="https://github.com/user-attachments/assets/8da1e820-0515-4ef1-bb06-6fd4158d688f" />
<img width="1286" height="840" alt="Снимок экрана 2025-07-23 в 20 53 26" src="https://github.com/user-attachments/assets/a733aac5-1b47-446b-97a9-251b77e4c9ad" />
<img width="1290" height="840" alt="Снимок экрана 2025-07-23 в 20 53 44" src="https://github.com/user-attachments/assets/b3824a8f-7be1-4550-8d39-940eb852db6b" />

## 🔍 Checklist

- [x] PR title is clear and descriptive
- [ ] All new code is covered by tests (if applicable)
- [x] Code follows project conventions and structure
- [x] No ESLint / Type errors
- [ ] Storybook stories added / updated (if UI)
- [ ] SonarCloud analysis passed without issues (code smells, bugs, duplications)
